### PR TITLE
Change HashRouter to BrowserRouter, remove unnecessary api endpoint

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -46,9 +46,9 @@ const ThemeProvider = () => {
 root.render(
   // <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <HashRouter>
+      <BrowserRouter>
         <ThemeProvider />
-      </HashRouter>
+      </BrowserRouter>
     </QueryClientProvider>
   // </React.StrictMode>
 )

--- a/matching/urls.py
+++ b/matching/urls.py
@@ -2,6 +2,6 @@ from django.urls import path
 from .views import workflow_matcher_view, workflow_matcher
 
 urlpatterns = [
-    path('search/', workflow_matcher_view, name='matcher'),
+    # path('search/', workflow_matcher_view, name='matcher'),
     path('api/search/fabrication-workflow/', workflow_matcher, name='fabrication_workflow'),
 ]


### PR DESCRIPTION
- Changes HashRouter to BrowserRouter
- Removes search/ endpoint for workflow_matcher_view, that is no longer needed